### PR TITLE
Initialize $payload

### DIFF
--- a/lib/Base.php
+++ b/lib/Base.php
@@ -112,6 +112,8 @@ class Base {
     // Masking?
     $mask = (boolean) (ord($data[1]) >> 7);  // Bit 0 in byte 1
 
+    $payload = "";
+    
     // Payload length
     $payload_length = (integer) ord($data[1]) & 127; // Bits 1-7 in byte 1
     if ($payload_length > 125) {


### PR DESCRIPTION
Initialize $payload. As sometimes (with Slack) we get a websocket packet with payload_length == 0 (probably a ping packet or something?) This will break the `return $payload`, as it will not have been initialized.