### PR TITLE
Add port in Host request-header during handshake

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -70,7 +70,7 @@ class Client extends Base {
 
     // Default headers (using lowercase for simpler array_merge below).
     $headers = array(
-      'host'                  => $host,
+      'host'                  => $host . ":" . $port,
       'user-agent'            => 'websocket-client-php',
       'connection'            => 'Upgrade',
       'upgrade'               => 'websocket',

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -231,7 +231,7 @@ class WebSocketTest extends PHPUnit_Framework_TestCase {
 
     $this->assertRegExp(
       "/GET \/$this->test_id HTTP\/1.1\r\n"
-      . "host: localhost\r\n"
+      . "host: localhost:".self::$port."\r\n"
       . "user-agent: websocket-client-php\r\n"
       . "connection: Upgrade\r\n"
       . "upgrade: websocket\r\n"
@@ -251,7 +251,7 @@ class WebSocketTest extends PHPUnit_Framework_TestCase {
 
     $this->assertRegExp(
       "/GET \/$this->test_id HTTP\/1.1\r\n"
-      . "host: localhost\r\n"
+      . "host: localhost:".self::$port."\r\n"
       . "user-agent: Deep thought\r\n"
       . "connection: Upgrade\r\n"
       . "upgrade: websocket\r\n"
@@ -271,7 +271,7 @@ class WebSocketTest extends PHPUnit_Framework_TestCase {
 
     $this->assertRegExp(
       "/GET \/$this->test_id HTTP\/1.1\r\n"
-      . "host: localhost\r\n"
+      . "host: localhost:".self::$port."\r\n"
       . "user-agent: websocket-client-php\r\n"
       . "connection: Upgrade\r\n"
       . "upgrade: websocket\r\n"


### PR DESCRIPTION
Some websocket servers (in my case Autobahn) does not accept Host headers that does not include the port if the port is non-standard, and returns an HTTP error : 

`HTTP/1.1 400 missing port in HTTP Host header 'localhost' and server runs on non-standard port 9000`

This patches fixes this error