### PR TITLE
Stream context option support

### DIFF
--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -313,4 +313,34 @@ class WebSocketTest extends PHPUnit_Framework_TestCase {
     $size = $ws->setFragmentSize(123)->getFragmentSize();
     $this->assertSame(123, $size);
   }
+
+  public function testSetStreamContextOptions() {
+    $context = stream_context_create();
+    stream_context_set_option($context, 'ssl', 'verify_peer', true);
+    stream_context_set_option($context, 'ssl', 'verify_host', true);
+    stream_context_set_option($context, 'ssl', 'allow_self_signed', true);
+
+    $options = [
+      'context' => $context
+    ];
+
+    $ws = new Client('ws://localhost:' . self::$port, $options);
+    $ws->send('foo');
+    $this->assertTrue(get_resource_type($ws->options['context']) === 'stream-context');
+  }
+
+  /**
+   * @expectedException \InvalidArgumentException
+   * @expectedExceptionMessage Stream context in $options['context'] isn't a valid context
+   */
+  public function testSetInvalidStreamContextOptions() {
+    $context = false;
+
+    $options = [
+        'context' => $context
+    ];
+
+    $ws = new Client('ws://localhost:' . self::$port, $options);
+    $ws->send('foo');
+  }
 }

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -320,9 +320,9 @@ class WebSocketTest extends PHPUnit_Framework_TestCase {
     stream_context_set_option($context, 'ssl', 'verify_host', true);
     stream_context_set_option($context, 'ssl', 'allow_self_signed', true);
 
-    $options = [
+    $options = array(
       'context' => $context
-    ];
+    );
 
     $ws = new Client('ws://localhost:' . self::$port, $options);
     $ws->send('foo');
@@ -336,9 +336,9 @@ class WebSocketTest extends PHPUnit_Framework_TestCase {
   public function testSetInvalidStreamContextOptions() {
     $context = false;
 
-    $options = [
+    $options = array(
         'context' => $context
-    ];
+    );
 
     $ws = new Client('ws://localhost:' . self::$port, $options);
     $ws->send('foo');


### PR DESCRIPTION
Swapped fsockopen to stream_socket_client and added context option in the constructor options. This is a better solution than suggested in #21 since it allows passing in any stream context options without modifying the base code.