### PR TITLE
'Do not block' parameter in receive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
         "phpunit/phpunit-selenium": "1.3.3",
         "satooshi/php-coveralls": "dev-master",
         "cboden/ratchet": "0.3.*"
+    },
+    "require": {
+        "php" : "~5.4 || ~7.0"
     }
 }

--- a/lib/Base.php
+++ b/lib/Base.php
@@ -12,7 +12,7 @@ namespace WebSocket;
 
 class Base {
   protected $socket, $is_connected = false, $is_closing = false, $last_opcode = null,
-    $close_status = null, $huge_payload = null;
+    $close_status = null, $huge_payload = '';
 
   protected static $opcodes = array(
     'continuation' => 0,
@@ -136,8 +136,6 @@ class Base {
 
   public function receive($try = false) {
     if (!$this->is_connected) $this->connect(); /// @todo This is a client function, fixme!
-
-    $this->huge_payload = '';
 
     $response = null;
     do {
@@ -285,7 +283,7 @@ class Base {
     else if ($this->huge_payload) {
       // sp we need to retreive the whole payload
       $payload = $this->huge_payload .= $payload;
-      $this->huge_payload = null;
+      $this->huge_payload = '';
     }
 
     return $payload;

--- a/lib/Base.php
+++ b/lib/Base.php
@@ -137,6 +137,46 @@ class Base {
     return $response;
   }
 
+  protected $unparsed_fragment = '';
+
+  protected function receive_fragment_header() {
+    $minimum_size = 2;
+    $minimum_remain = strlen($this->unparsed_fragment) - $minimum_size;
+
+    if ($this->will_block($minimum_remain))
+      return null;
+
+    $this->unparsed_fragment .= $this->read($minimum_remain);
+
+    $payload_length = (integer) ord($data[1]) & 127; // Bits 1-7 in byte 1
+    if ($payload_length <= 125)
+
+
+    switch ($payload_length)
+    {
+    default:
+      return $this->unparsed_fragment;
+    case 126:
+      $extra_header_bytes = 2;
+      break;
+    case 127:
+      $extra_header_bytes = 8;
+      break;
+    }
+
+    $extra_remain =
+      $minimum_size
+      + $extra_header_bytes
+      - strlen($this->unparsed_fragment);
+
+    if ($this->will_block($extra_remain))
+      return null;
+
+    $this->unparsed_fragment .= $this->read($extra_remain);
+
+    return $this->unparsed_fragment;
+  }
+
   protected function receive_fragment() {
 
     // Just read the main fragment information first.

--- a/lib/Base.php
+++ b/lib/Base.php
@@ -275,6 +275,15 @@ class Base {
     return $data;
   }
 
+  protected function will_block($length) {
+    return $this->unreaded() < $length;
+  }
+
+  protected function unreaded() {
+    $metadata = stream_get_meta_data($this->socket);
+    return $metadata['unread_bytes'];
+  }
+
 
   /**
    * Helper to convert a binary to a string of '0' and '1'.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -160,6 +160,9 @@ class Client extends Base {
       throw new ConnectionException('Server sent bad upgrade response.');
     }
 
+    // Set non blocking mode
+    stream_set_blocking($this->socket, false);
+
     $this->is_connected = true;
   }
 

--- a/lib/Server.php
+++ b/lib/Server.php
@@ -64,6 +64,8 @@ class Server extends Base {
 
     $this->performHandshake();
 
+    stream_set_blocking($this->socket, false);
+
     return $this->socket;
   }
 

--- a/tests/ClientTracker.php
+++ b/tests/ClientTracker.php
@@ -45,9 +45,9 @@ class ClientTracker extends Client {
 	/**
 	 * Reset the receive counter
 	 */
-	public function receive() {
+	public function receive($try = false) {
 		$this->fragment_count['receive'] = 0;
-		return parent::receive();
+		return parent::receive($try);
 	}
 
 	/**


### PR DESCRIPTION
I made minor code refactoring, removed magic bitwise operations. But most importantly i am made code that trying to read fragment, and if it's not yet buffered - operation delayed. Each time user requests fragment it trying to complete receiving operation.

I just added method `bufferize($length)` which tried to read data from socket in non-blocking mode, and store it in RAM. `receive_fragment` will continue its work only when all data already in RAM.

When new argument in `receive($flag)` set to `true`, then this method will not block execution, and try construct packet only once.
