### PR TITLE
.travis.yml - Added dist option to force distro version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 
 php:
   - 7.1


### PR DESCRIPTION
Seems like all the builds on travis are failing due to `Xenial` being the new default.

https://travis-ci.community/t/php-5-4-and-5-5-archives-missing/3723/5