### PR TITLE
Fix bug with empty response message

### DIFF
--- a/lib/Base.php
+++ b/lib/Base.php
@@ -71,23 +71,13 @@ class Base
             throw new BadOpcodeException("Bad opcode '$opcode'.  Try 'text' or 'binary'.");
         }
 
-        // record the length of the payload
-        $payload_length = strlen($payload);
+        $payload_chunks = str_split($payload, $this->options['fragment_size']);
 
-        $fragment_cursor = 0;
-        // while we have data to send
-        while ($payload_length > $fragment_cursor) {
-            // get a fragment of the payload
-            $sub_payload = substr($payload, $fragment_cursor, $this->options['fragment_size']);
+        for ($index = 0; $index < count($payload_chunks); ++$index) {
+            $chunk = $payload_chunks[$index];
+            $final = $index == count($payload_chunks) - 1;
 
-            // advance the cursor
-            $fragment_cursor += $this->options['fragment_size'];
-
-            // is this the final fragment to send?
-            $final = $payload_length <= $fragment_cursor;
-
-            // send the fragment
-            $this->sendFragment($final, $sub_payload, $opcode, $masked);
+            $this->sendFragment($final, $chunk, $opcode, $masked);
 
             // all fragments after the first will be marked a continuation
             $opcode = 'continuation';

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -162,6 +162,11 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Server ping', $message);
         $this->assertEquals('pong', $client->getLastOpcode());
 
+        $client->send('', 'ping');
+        $message = $client->receive();
+        $this->assertEquals('', $message);
+        $this->assertEquals('pong', $client->getLastOpcode());
+
         $message = $client->receive();
         $this->assertEquals('Client ping', $message);
         $this->assertTrue(MockSocket::isEmpty());

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -165,6 +165,11 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Server ping', $message);
         $this->assertEquals('pong', $server->getLastOpcode());
 
+        $server->send('', 'ping');
+        $message = $server->receive();
+        $this->assertEquals('', $message);
+        $this->assertEquals('pong', $server->getLastOpcode());
+
         $message = $server->receive();
         $this->assertEquals('Client ping', $message);
 

--- a/tests/scripts/ping-pong.json
+++ b/tests/scripts/ping-pong.json
@@ -55,6 +55,45 @@
         "return": "stream"
     },
     {
+        "function": "fwrite",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": 6
+    },
+    {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "stream"
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            2
+        ],
+        "return-op": "chr-array",
+        "return": [138, 128]
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            4
+        ],
+        "return-op": "chr-array",
+        "return": [1, 1, 1, 1]
+    },
+    {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "stream"
+    },
+    {
         "function": "fread",
         "params": [
             "@mock-stream",


### PR DESCRIPTION
According to [rfc](https://tools.ietf.org/html/rfc6455#section-5.5.2) documentation, ping message **may** not include application data.
But pong frame **must** have identical application data as found in ping message.

So, this patch make ability to send empty response pong for empty request ping.