### PR TITLE
[v1.4] PHP version ^7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: php
-dist: trusty
 
 php:
   - 7.4
   - 7.3
   - 7.2
   - 7.1
-  - 7.0
-  - 5.6
-  - 5.5
-  - 5.4
 
 before_script:
   - make install build
 
 script:
-  - make coverage cs-check
+  - make coverage
+  - make cs-check

--- a/codestandard.xml
+++ b/codestandard.xml
@@ -6,7 +6,5 @@
     <arg name="colors"/>
 
     <rule ref="PSR1"/>
-    <rule ref="PSR12">
-        <exclude name="PSR12.Properties.ConstantVisibility"/>
-    </rule>
+    <rule ref="PSR12"/>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
     "type": "library",
     "authors": [
         {
-            "name": "Fredrik Liljegren",
-            "email": "fredrik.liljegren@textalk.se"
+            "name": "Fredrik Liljegren"
         },
         {
             "name": "Sören Jensen",
@@ -24,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^5.4|^7.0"
+        "php": "^7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.1",

--- a/lib/ConnectionException.php
+++ b/lib/ConnectionException.php
@@ -5,7 +5,7 @@ namespace WebSocket;
 class ConnectionException extends Exception
 {
     // Native codes in interval 0-106
-    const TIMED_OUT = 1024;
-    const EOF = 1025;
-    const BAD_OPCODE = 1026;
+    public const TIMED_OUT = 1024;
+    public const EOF = 1025;
+    public const BAD_OPCODE = 1026;
 }


### PR DESCRIPTION
Dropping support for old PHP versions, `5.x ` and `7.0`.

This enables us to replace deprecated dependencies and use more modern PHP code.

Scheduled for `v1.4` release.