### PR TITLE
Introduce TimeoutException as a type of ConnectionException

### DIFF
--- a/lib/Base.php
+++ b/lib/Base.php
@@ -306,13 +306,14 @@ class Base
     protected function throwException($message, $code = 0)
     {
         $meta = stream_get_meta_data($this->socket);
+        $json_meta = json_encode($meta);
         if (!empty($meta['timed_out'])) {
             $code = ConnectionException::TIMED_OUT;
+            throw new TimeoutException("$message Stream state: $json_meta", $code);
         }
         if (!empty($meta['eof'])) {
             $code = ConnectionException::EOF;
         }
-        $json_meta = json_encode($meta);
         throw new ConnectionException("$message  Stream state: $json_meta", $code);
     }
 

--- a/lib/TimeoutException.php
+++ b/lib/TimeoutException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace WebSocket;
+
+class TimeoutException extends ConnectionException
+{
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -338,7 +338,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        WebSocket\ConnectionException
+     * @expectedException        WebSocket\TimeoutException
      * @expectedExceptionCode    1024
      * @expectedExceptionMessage Failed to write 22 bytes.
      */
@@ -366,7 +366,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        WebSocket\ConnectionException
+     * @expectedException        WebSocket\TimeoutException
      * @expectedExceptionCode    1024
      * @expectedExceptionMessage Empty read; connection dead?
      */


### PR DESCRIPTION
Hello,

I'm hoping this change isn't too intrusive but I wanted to introduce a more granular type of connection exception. I have a separate patch coming that introduces persistence as a client connection option and one of the possibilities it introduces is the idea that the re-used connection from a previous request may time out. Some client applications using persistence as an option may want to easily catch a timeout and attempt to re-connect.

Thanks,
Michael