### PR TITLE
Adding persistent connection option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The `$options` parameter in constructor accepts an associative array of options.
 * `fragment_size` - Maximum payload size. Default 4096 chars.
 * `context` - A stream context created using [stream_context_create](https://www.php.net/manual/en/function.stream-context-create).
 * `headers` - Additional headers as associative array name => content.
+* `persistent` - Connection is re-used between requests until time out is reached. Default false.
 
 ```php
 $context = stream_context_create();
@@ -185,6 +186,7 @@ $server = new WebSocket\Server([
 * `WebSocket\BadOpcodeException` - Thrown if provided opcode is invalid.
 * `WebSocket\BadUriException` - Thrown if provided URI is invalid.
 * `WebSocket\ConnectionException` - Thrown on any socket I/O failure.
+* `WebSocket\TimeoutExeception` - Thrown when the socket experiences a time out.
 
 
 ## Development and contribution

--- a/lib/Base.php
+++ b/lib/Base.php
@@ -277,11 +277,13 @@ class Base
         $written = fwrite($this->socket, $data);
         if ($written === false) {
             $length = strlen($data);
+            fclose($this->socket);
             $this->throwException("Failed to write $length bytes.");
         }
 
         if ($written < strlen($data)) {
             $length = strlen($data);
+            fclose($this->socket);
             $this->throwException("Could only write $written out of $length bytes.");
         }
     }

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -13,6 +13,7 @@ class Client extends Base
 {
     // Default options
     protected static $default_options = [
+      'persistent'    => false,
       'timeout'       => 5,
       'fragment_size' => 4096,
       'context'       => null,
@@ -95,13 +96,16 @@ class Client extends Base
             $context = stream_context_create();
         }
 
+        $flags = STREAM_CLIENT_CONNECT;
+        $flags = ($this->options['persistent'] === true) ? $flags | STREAM_CLIENT_PERSISTENT : $flags;
+
         // Open the socket.  @ is there to supress warning that we will catch in check below instead.
         $this->socket = @stream_socket_client(
             $host_uri . ':' . $port,
             $errno,
             $errstr,
             $this->options['timeout'],
-            STREAM_CLIENT_CONNECT,
+            $flags,
             $context
         );
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -226,6 +226,14 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(MockSocket::isEmpty());
     }
 
+    public function testPersistentConnection()
+    {
+        MockSocket::initialize('client.connect-persistent', $this);
+        $client = new Client('ws://localhost:8000/my/mock/path', ['persistent' => true]);
+        $client->send('Connect');
+        $this->assertTrue(MockSocket::isEmpty());
+    }
+
     /**
      * @expectedException        WebSocket\BadUriException
      * @expectedExceptionMessage Url should have scheme ws or wss

--- a/tests/scripts/client.connect-persistent.json
+++ b/tests/scripts/client.connect-persistent.json
@@ -1,0 +1,60 @@
+[
+    {
+        "function": "stream_context_create",
+        "params": [],
+        "return": "@mock-stream-context"
+    },
+    {
+        "function": "stream_socket_client",
+        "params": [
+            "tcp:\/\/localhost:8000",
+            null,
+            null,
+            5,
+            5,
+            "@mock-stream-context"
+        ],
+        "return": "@mock-stream"
+    },
+    {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "stream"
+    },
+    {
+        "function": "stream_set_timeout",
+        "params": [
+            "@mock-stream",
+            5
+        ],
+        "return": true
+    },
+    {
+        "function": "fwrite",
+        "params": [
+            "@mock-stream"
+        ],
+        "return-op": "key-save",
+        "return": 248
+    },
+    {
+        "function": "stream_get_line",
+        "params": [
+            "@mock-stream",
+            1024,
+            "\r\n\r\n"
+        ],
+        "return-op": "key-respond",
+        "return": "HTTP\/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {key}"
+    },
+    {
+        "function": "fwrite",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": 13
+    }
+]
+

--- a/tests/scripts/send-broken-write.json
+++ b/tests/scripts/send-broken-write.json
@@ -14,6 +14,11 @@
         "return": 18
     },
     {
+        "function": "fclose",
+        "params": [],
+        "return": true
+    },
+    {
         "function": "stream_get_meta_data",
         "params": [
             "@mock-stream"

--- a/tests/scripts/send-failed-write.json
+++ b/tests/scripts/send-failed-write.json
@@ -14,6 +14,11 @@
         "return": false
     },
     {
+        "function": "fclose",
+        "params": [],
+        "return": true
+    },
+    {
         "function": "stream_get_meta_data",
         "params": [
             "@mock-stream"


### PR DESCRIPTION
Hello,

I'd like to propose adding a "persistent" boolean option to the list of available options for a websocket client. When this option is used, it's possible for a connection from a previous request to timeout. It's suggested that if "fwrite" returns false, that "fclose" needs to be called for the resource to be let go. https://www.php.net/manual/en/function.pfsockopen.php#108929

Regards,
Michael