### PR TITLE
check if functions are disabled if failed to connect/listen

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -112,6 +112,11 @@ class Client extends Base
         );
 
         if (!$this->isConnected()) {
+            if ($errstr === null && !function_exists('stream_socket_client')) {
+                // @codeCoverageIgnoreStart
+                $errstr = 'stream_socket_client function is disabled';
+                // @codeCoverageIgnoreEnd
+            }
             $error = "Could not open socket to \"{$host}:{$port}\": {$errstr} ({$errno}).";
             $this->logger->error($error);
             throw new ConnectionException($error);

--- a/lib/Server.php
+++ b/lib/Server.php
@@ -43,6 +43,11 @@ class Server extends Base
         } while ($this->listening === false && $this->port++ < 10000);
 
         if (!$this->listening) {
+            if ($errstr === null && !function_exists('stream_socket_server')) {
+                // @codeCoverageIgnoreStart
+                $errstr = 'stream_socket_server function is disabled';
+                // @codeCoverageIgnoreEnd
+            }
             $error = "Could not open listening socket: {$errstr} ({$errno})";
             $this->logger->error($error);
             throw new ConnectionException($error, $errno);


### PR DESCRIPTION
Closes #93 

Currently, if a user attempts to use these functions while they are disabled via php.ini, they will receive a message like `Could not open socket to "127.0.0.1:41983":  ()`. This has can cause confusion to someone who might not know the function is disabled (or that you can disable functions), and just lead to spinning their wheels on trying to debug.

This patch changes it such that if `$errstr` is null, it will check if the function is disabled and if so, will update the `$errstr` variable to something more meaningful to be displayed to the user and logged. The `$errno` variable remains null. In the above example, the user will now receive the following error message: `Could not open socket to "127.0.0.1:41983": stream_socket_client function is disabled ()`.

Given that this code relies on the function not existing, I'm not sure how I would include tests for this behavior. As such, I've ignored the lines in question for consideration of code coverage.