### PR TITLE
fix bug in isConnected function when evaluating persistent connections

### DIFF
--- a/lib/Base.php
+++ b/lib/Base.php
@@ -43,7 +43,9 @@ class Base implements LoggerAwareInterface
 
     public function isConnected()
     {
-        return $this->socket && get_resource_type($this->socket) == 'stream';
+        return $this->socket &&
+            (get_resource_type($this->socket) == 'stream' ||
+             get_resource_type($this->socket) == 'persistent stream');
     }
 
     public function setTimeout($timeout)

--- a/tests/scripts/client.connect-persistent.json
+++ b/tests/scripts/client.connect-persistent.json
@@ -21,7 +21,14 @@
         "params": [
             "@mock-stream"
         ],
-        "return": "stream"
+        "return": "persistent stream"
+    },
+    {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "persistent stream"
     },
     {
         "function": "stream_set_timeout",

--- a/tests/scripts/client.reconnect.json
+++ b/tests/scripts/client.reconnect.json
@@ -7,6 +7,13 @@
         "return": "Unknown"
     },
     {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "stream"
+    },
+    {
         "function": "stream_context_create",
         "params": [],
         "return": "@mock-stream-context"


### PR DESCRIPTION
A friend of mine made the original change for supporting persistent connections, but it seems to have an issue.

When you set the persistent flag on a socket stream, php changes the resource type from "stream" to "persistent stream". This causes the isConnected() function on Websocket\Base to erroneously assume that the resource type is invalid, preventing us from resolving the connect function.

I've updated the isConnected() function to account for this issue and updated tests accordingly.