### PR TITLE
Ping & Pong, handle internally, continue reading

### DIFF
--- a/lib/Base.php
+++ b/lib/Base.php
@@ -217,9 +217,10 @@ class Base
             }
         }
 
-        // if we received a ping, send a pong
+        // if we received a ping, send a pong and wait for the next message
         if ($opcode === 'ping') {
             $this->send($payload, 'pong', true);
+            return [null, false];
         }
 
         if ($opcode === 'close') {

--- a/lib/Base.php
+++ b/lib/Base.php
@@ -192,11 +192,6 @@ class Base implements LoggerAwareInterface
         }
         $opcode = $opcode_ints[$opcode_int];
 
-        // Record the opcode if we are not receiving a continutation fragment
-        if ($opcode !== 'continuation') {
-            $this->last_opcode = $opcode;
-        }
-
         // Masking?
         $mask = (bool) (ord($data[1]) >> 7);  // Bit 0 in byte 1
 
@@ -237,6 +232,17 @@ class Base implements LoggerAwareInterface
             $this->logger->debug("Received 'ping', sending 'pong'.");
             $this->send($payload, 'pong', true);
             return [null, false];
+        }
+
+        // if we received a pong, wait for the next message
+        if ($opcode === 'pong') {
+            $this->logger->debug("Received 'pong'.");
+            return [null, false];
+        }
+
+        // Record the opcode if we are not receiving a continutation fragment
+        if ($opcode !== 'continuation') {
+            $this->last_opcode = $opcode;
         }
 
         if ($opcode === 'close') {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -162,19 +162,11 @@ class ClientTest extends TestCase
 
         MockSocket::initialize('ping-pong', $this);
         $client->send('Server ping', 'ping');
-        $message = $client->receive();
-        $this->assertEquals('Server ping', $message);
-        $this->assertEquals('pong', $client->getLastOpcode());
-
         $client->send('', 'ping');
         $message = $client->receive();
-        $this->assertEquals('', $message);
-        $this->assertEquals('pong', $client->getLastOpcode());
-
-        $message = $client->receive();
-        $this->assertEquals('Client ping', $message);
+        $this->assertEquals('Receiving a message', $message);
+        $this->assertEquals('text', $client->getLastOpcode());
         $this->assertTrue(MockSocket::isEmpty());
-        $this->assertEquals('ping', $client->getLastOpcode());
     }
 
     public function testRemoteClose(): void

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -165,20 +165,11 @@ class ServerTest extends TestCase
 
         MockSocket::initialize('ping-pong', $this);
         $server->send('Server ping', 'ping');
-        $message = $server->receive();
-        $this->assertEquals('Server ping', $message);
-        $this->assertEquals('pong', $server->getLastOpcode());
-
         $server->send('', 'ping');
         $message = $server->receive();
-        $this->assertEquals('', $message);
-        $this->assertEquals('pong', $server->getLastOpcode());
-
-        $message = $server->receive();
-        $this->assertEquals('Client ping', $message);
-
+        $this->assertEquals('Receiving a message', $message);
+        $this->assertEquals('text', $server->getLastOpcode());
         $this->assertTrue(MockSocket::isEmpty());
-        $this->assertEquals('ping', $server->getLastOpcode());
     }
 
     public function testRemoteClose(): void

--- a/tests/scripts/ping-pong.json
+++ b/tests/scripts/ping-pong.json
@@ -21,6 +21,20 @@
         "return": "stream"
     },
     {
+        "function": "fwrite",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": 6
+    },
+    {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "stream"
+    },
+    {
         "function": "fread",
         "params": [
             "@mock-stream",
@@ -48,27 +62,6 @@
         "return": [82, 100, 115, 119, 100, 115, 33, 113, 104, 111, 102]
     },
     {
-        "function": "get_resource_type",
-        "params": [
-            "@mock-stream"
-        ],
-        "return": "stream"
-    },
-    {
-        "function": "fwrite",
-        "params": [
-            "@mock-stream"
-        ],
-        "return": 6
-    },
-    {
-        "function": "get_resource_type",
-        "params": [
-            "@mock-stream"
-        ],
-        "return": "stream"
-    },
-    {
         "function": "fread",
         "params": [
             "@mock-stream",
@@ -85,13 +78,6 @@
         ],
         "return-op": "chr-array",
         "return": [1, 1, 1, 1]
-    },
-    {
-        "function": "get_resource_type",
-        "params": [
-            "@mock-stream"
-        ],
-        "return": "stream"
     },
     {
         "function": "fread",
@@ -133,5 +119,32 @@
             "@mock-stream"
         ],
         "return": 17
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            2
+        ],
+        "return-op": "chr-array",
+        "return": [129, 147]
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            4
+        ],
+        "return-op": "chr-array",
+        "return": [33, 111, 149, 174]
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            19
+        ],
+        "return-op": "chr-array",
+        "return": [115, 10, 246, 203, 72, 25, 252, 192, 70, 79, 244, 142, 76, 10, 230, 221, 64, 8, 240]
     }
 ]


### PR DESCRIPTION
Messages of type `ping` and `pong` are completely handled internally, and never returned to calling code. This behavior ensures that fragmented messages don't break when a control message occurs between fragments.

Replaces PR https://github.com/Textalk/websocket-php/pull/87