### PR TITLE
Header line break fix

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -135,7 +135,7 @@ class Client extends Base
 
         // Handle basic authentication.
         if ($user || $pass) {
-            $headers['authorization'] = 'Basic ' . base64_encode($user . ':' . $pass) . "\r\n";
+            $headers['authorization'] = 'Basic ' . base64_encode($user . ':' . $pass);
         }
 
         // Deprecated way of adding origin (use headers instead).


### PR DESCRIPTION
Line breaks are applied later. Current code added an extra line break on `authorization` header.

Closing https://github.com/Textalk/websocket-php/issues/107