### PR TITLE
Receiver rewrite

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,15 @@
 
 # Websocket: Changelog
 
+## `v1.5`
+
+ > PHP version `^7.2`
+
+### `1.5.0`
+
+ * Opcode filter for receive() method (@sirn-se)
+ * Fix for unordered framgemented messages (@sirn-se)
+
 ## `v1.4`
 
  > PHP version `^7.1`

--- a/docs/Client.md
+++ b/docs/Client.md
@@ -66,9 +66,11 @@ By default the `receive()` method return messages of 'text' and 'binary' opcode.
 The filter option allows you to specify which message types to return.
 
 ```php
-$client->receive(); // return 'text' and 'binary' messages
-$client->receive(['filter' => ['text']]); // only return 'text' messages
-$client->receive(['filter' => ['text', 'binary', 'ping', 'pong', 'close']]); // return all messages
+$client = new WebSocket\Client("ws://echo.websocket.org/", ['filter' => ['text']]);
+$client->receive(); // only return 'text' messages
+
+$client = new WebSocket\Client("ws://echo.websocket.org/", ['filter' => ['text', 'binary', 'ping', 'pong', 'close']]);
+$client->receive(); // return all messages
 ```
 
 
@@ -76,6 +78,7 @@ $client->receive(['filter' => ['text', 'binary', 'ping', 'pong', 'close']]); // 
 
 The `$options` parameter in constructor accepts an associative array of options.
 
+* `filter` - Array of opcodes to return on receive, default `['text', 'binary']`
 * `timeout` - Time out in seconds. Default 5 seconds.
 * `fragment_size` - Maximum payload size. Default 4096 chars.
 * `context` - A stream context created using [stream_context_create](https://www.php.net/manual/en/function.stream-context-create).

--- a/docs/Client.md
+++ b/docs/Client.md
@@ -14,10 +14,10 @@ WebSocket\Client {
     public __destruct()
 
     public send(mixed $payload, string $opcode = 'text', bool $masked = true) : void
-    public receive() : mixed
+    public receive(array $options = ['filter' => ['text', 'binary']]) : ?string
     public close(int $status = 1000, mixed $message = 'ttfn') : mixed
 
-    public getLastOpcode() : string
+    public getLastOpcode(bool $frame = false) : string
     public getCloseStatus() : int
     public isConnected() : bool
     public setTimeout(int $seconds) : void
@@ -59,6 +59,18 @@ while (true) {
 }
 $client->close();
 ```
+
+### Filtering received messages
+
+By default the `receive()` method return messages of 'text' and 'binary' opcode.
+The filter option allows you to specify which message types to return.
+
+```php
+$client->receive(); // return 'text' and 'binary' messages
+$client->receive(['filter' => ['text']]); // only return 'text' messages
+$client->receive(['filter' => ['text', 'binary', 'ping', 'pong', 'close']]); // return all messages
+```
+
 
 ## Constructor options
 

--- a/docs/Client.md
+++ b/docs/Client.md
@@ -14,7 +14,7 @@ WebSocket\Client {
     public __destruct()
 
     public send(mixed $payload, string $opcode = 'text', bool $masked = true) : void
-    public receive(array $options = ['filter' => ['text', 'binary']]) : ?string
+    public receive() : ?string
     public close(int $status = 1000, mixed $message = 'ttfn') : mixed
 
     public getLastOpcode(bool $frame = false) : string

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -18,7 +18,7 @@ WebSocket\Server {
 
     public accept() : bool
     public send(mixed $payload, string $opcode = 'text', bool $masked = true) : void
-    public receive() : mixed
+    public receive(array $options = ['filter' => ['text', 'binary']]) : ?string
     public close(int $status = 1000, mixed $message = 'ttfn') : mixed
 
     public getPort() : int
@@ -26,7 +26,7 @@ WebSocket\Server {
     public getRequest() : array
     public getHeader(string $header_name) : string|null
 
-    public getLastOpcode() : string
+    public getLastOpcode(bool $frame = false) : string
     public getCloseStatus() : int
     public isConnected() : bool
     public setTimeout(int $seconds) : void
@@ -68,6 +68,17 @@ while ($server->accept()) {
     }
 }
 $server->close();
+```
+
+### Filtering received messages
+
+By default the `receive()` method return messages of 'text' and 'binary' opcode.
+The filter option allows you to specify which message types to return.
+
+```php
+$client->receive(); // return 'text' and 'binary' messages
+$client->receive(['filter' => ['text']]); // only return 'text' messages
+$client->receive(['filter' => ['text', 'binary', 'ping', 'pong', 'close']]); // return all messages
 ```
 
 ## Constructor options

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -18,7 +18,7 @@ WebSocket\Server {
 
     public accept() : bool
     public send(mixed $payload, string $opcode = 'text', bool $masked = true) : void
-    public receive(array $options = ['filter' => ['text', 'binary']]) : ?string
+    public receive() : ?string
     public close(int $status = 1000, mixed $message = 'ttfn') : mixed
 
     public getPort() : int

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -76,15 +76,18 @@ By default the `receive()` method return messages of 'text' and 'binary' opcode.
 The filter option allows you to specify which message types to return.
 
 ```php
-$client->receive(); // return 'text' and 'binary' messages
-$client->receive(['filter' => ['text']]); // only return 'text' messages
-$client->receive(['filter' => ['text', 'binary', 'ping', 'pong', 'close']]); // return all messages
+$server = new WebSocket\Server(['filter' => ['text']]);
+$server->receive(); // only return 'text' messages
+
+$server = new WebSocket\Server(['filter' => ['text', 'binary', 'ping', 'pong', 'close']]);
+$server->receive(); // return all messages
 ```
 
 ## Constructor options
 
 The `$options` parameter in constructor accepts an associative array of options.
 
+* `filter` - Array of opcodes to return on receive, default `['text', 'binary']`
 * `timeout` - Time out in seconds. Default 5 seconds.
 * `port` - The server port to listen to. Default 8000.
 * `fragment_size` - Maximum payload size. Default 4096 chars.

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -13,13 +13,14 @@ class Client extends Base
 {
     // Default options
     protected static $default_options = [
-      'persistent'    => false,
-      'timeout'       => 5,
-      'fragment_size' => 4096,
       'context'       => null,
+      'filter'        => ['text', 'binary'],
+      'fragment_size' => 4096,
       'headers'       => null,
       'logger'        => null,
       'origin'        => null, // @deprecated
+      'persistent'    => false,
+      'timeout'       => 5,
     ];
 
     protected $socket_uri;

--- a/lib/Server.php
+++ b/lib/Server.php
@@ -13,10 +13,11 @@ class Server extends Base
 {
     // Default options
     protected static $default_options = [
-      'timeout'       => null,
+      'filter'        => ['text', 'binary'],
       'fragment_size' => 4096,
-      'port'          => 8000,
       'logger'        => null,
+      'port'          => 8000,
+      'timeout'       => null,
     ];
 
     protected $addr;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -40,12 +40,6 @@ class ClientTest extends TestCase
         $client->close();
         $this->assertFalse($client->isConnected());
         $this->assertEquals(1000, $client->getCloseStatus());
-        $this->assertEquals('close', $client->getLastOpcode());
-
-        $client->close();
-        $this->assertFalse($client->isConnected());
-        $this->assertEquals(1000, $client->getCloseStatus());
-        $this->assertEquals('close', $client->getLastOpcode());
 
         $this->assertTrue(MockSocket::isEmpty());
     }
@@ -179,11 +173,12 @@ class ClientTest extends TestCase
         MockSocket::initialize('close-remote', $this);
 
         $message = $client->receive();
-        $this->assertEquals('', $message);
+        $this->assertNull($message);
 
         $this->assertFalse($client->isConnected());
         $this->assertEquals(17260, $client->getCloseStatus());
-        $this->assertEquals('close', $client->getLastOpcode());
+        $this->assertNull($client->getLastOpcode());
+        $this->assertEquals('close', $client->getLastOpcode(true));
         $this->assertTrue(MockSocket::isEmpty());
     }
 
@@ -213,7 +208,8 @@ class ClientTest extends TestCase
         $client->close();
         $this->assertFalse($client->isConnected());
         $this->assertEquals(1000, $client->getCloseStatus());
-        $this->assertEquals('close', $client->getLastOpcode());
+        $this->assertNull($client->getLastOpcode());
+        $this->assertEquals('close', $client->getLastOpcode(true));
         $this->assertTrue(MockSocket::isEmpty());
 
         MockSocket::initialize('client.reconnect', $this);

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -24,7 +24,6 @@ class ServerTest extends TestCase
         MockSocket::initialize('server.construct', $this);
         $server = new Server();
         $this->assertTrue(MockSocket::isEmpty());
-
         MockSocket::initialize('server.accept', $this);
         $server->accept();
         $server->send('Connect');
@@ -60,7 +59,7 @@ class ServerTest extends TestCase
         $server->close();
         $this->assertFalse($server->isConnected());
         $this->assertEquals(1000, $server->getCloseStatus());
-        $this->assertEquals('close', $server->getLastOpcode());
+        $this->assertEquals('close', $server->getLastOpcode(true));
         $this->assertTrue(MockSocket::isEmpty());
 
         $server->close(); // Already closed
@@ -192,7 +191,8 @@ class ServerTest extends TestCase
         $this->assertTrue(MockSocket::isEmpty());
         $this->assertFalse($server->isConnected());
         $this->assertEquals(17260, $server->getCloseStatus());
-        $this->assertEquals('close', $server->getLastOpcode());
+        $this->assertNull($server->getLastOpcode());
+        $this->assertEquals('close', $server->getLastOpcode(true));
     }
 
     public function testSetTimeout(): void

--- a/tests/scripts/receive-fragmentation.json
+++ b/tests/scripts/receive-fragmentation.json
@@ -1,0 +1,126 @@
+[
+    {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "stream"
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            2
+        ],
+        "return-op": "chr-array",
+        "return": [1, 136]
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            4
+        ],
+        "return-op": "chr-array",
+        "return": [105, 29, 187, 18]
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            8
+        ],
+        "return-op": "chr-array",
+        "return": [36, 104, 215, 102, 0, 61, 221, 96]
+    },
+
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            2
+        ],
+        "return-op": "chr-array",
+        "return": [138, 139]
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            4
+        ],
+        "return-op": "chr-array",
+        "return": [1, 1, 1, 1]
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            11
+        ],
+        "return-op": "chr-array",
+        "return": [82, 100, 115, 119, 100, 115, 33, 113, 104, 111, 102]
+    },
+
+    {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "stream"
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            2
+        ],
+        "return-op": "chr-array",
+        "return": [0, 136]
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            4
+        ],
+        "return-op": "chr-array",
+        "return": [221, 240, 46, 69]
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            8
+        ],
+        "return-op": "chr-array",
+        "return": [188, 151, 67, 32, 179, 132, 14, 49]
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            2
+        ],
+        "return-op": "chr-array",
+        "return": [128, 131]
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            4
+        ],
+        "return-op": "chr-array",
+        "return": [9, 60, 117, 193]
+    },
+    {
+        "function": "fread",
+        "params": [
+            "@mock-stream",
+            3
+        ],
+        "return-op": "chr-array",
+        "return": [108, 79, 1]
+    }
+]


### PR DESCRIPTION
Re-writing the receive() method.

Better handling of interrupted fragmented messages. That is, when a control frame is received content frames in a fragmented messages. Handled by using an internal buffer.

Ability to specify which opcodes to return. Default is `text` and `binary`, but by specifying the filter other opcodes may be returned as well.

Method getLastOpcode() by default returns opcode of last returned message. With argument `true` it will instead return opcode of last read frame, regardless if it was returned or not.