### PR TITLE
Read fixes

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6,6 +6,12 @@
 
  > PHP version `^7.1`
 
+#### `1.4.2`
+
+ * Force stream close on read error (@sirn-se)
+ * Authorization headers line feed (@sirn-se)
+ * Documentation (@matias-pool, @sirn-se)
+
 #### `1.4.1`
 
  * Ping/Pong, handled internally to avoid breaking fragmented messages (@nshmyrev, @sirn-se)

--- a/lib/Base.php
+++ b/lib/Base.php
@@ -323,9 +323,11 @@ class Base implements LoggerAwareInterface
             $buffer = fread($this->socket, $length - strlen($data));
             if ($buffer === false) {
                 $read = strlen($data);
+                fclose($this->socket);
                 $this->throwException("Broken frame, read {$read} of stated {$length} bytes.");
             }
             if ($buffer === '') {
+                fclose($this->socket);
                 $this->throwException("Empty read; connection dead?");
             }
             $data .= $buffer;

--- a/tests/scripts/receive-broken-read.json
+++ b/tests/scripts/receive-broken-read.json
@@ -12,6 +12,13 @@
         "return": false
     },
     {
+        "function": "fclose",
+        "params": [
+            "@mock-stream"
+        ],
+        "return":true
+    },
+    {
         "function": "stream_get_meta_data",
         "params": [
             "@mock-stream"

--- a/tests/scripts/receive-empty-read.json
+++ b/tests/scripts/receive-empty-read.json
@@ -12,6 +12,13 @@
         "return": ""
     },
     {
+        "function": "fclose",
+        "params": [
+            "@mock-stream"
+        ],
+        "return":true
+    },
+    {
         "function": "stream_get_meta_data",
         "params": [
             "@mock-stream"


### PR DESCRIPTION
Ensure failed read operations also close stream. If not, the stream might appear usable and not automatically reconnect as expected. We already do this on write operations.