### PR TITLE
Name methods

### DIFF
--- a/docs/Client.md
+++ b/docs/Client.md
@@ -12,6 +12,7 @@ WebSocket\Client {
 
     public __construct(string $uri, array $options = [])
     public __destruct()
+    public __toString() : string
 
     public text(string $payload) : void
     public binary(string $payload) : void
@@ -21,6 +22,8 @@ WebSocket\Client {
     public receive() : ?string
     public close(int $status = 1000, mixed $message = 'ttfn') : mixed
 
+    public getName() : string|null
+    public getRemoteName() : string|null
     public getLastOpcode(bool $frame = false) : string
     public getCloseStatus() : int
     public isConnected() : bool

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -15,6 +15,7 @@ WebSocket\Server {
 
     public __construct(array $options = [])
     public __destruct()
+    public __toString() : string
 
     public accept() : bool
     public text(string $payload) : void
@@ -30,6 +31,8 @@ WebSocket\Server {
     public getRequest() : array
     public getHeader(string $header_name) : string|null
 
+    public getName() : string|null
+    public getRemoteName() : string|null
     public getLastOpcode(bool $frame = false) : string
     public getCloseStatus() : int
     public isConnected() : bool

--- a/lib/Base.php
+++ b/lib/Base.php
@@ -143,6 +143,37 @@ class Base implements LoggerAwareInterface
         $this->send($payload, 'pong');
     }
 
+    /**
+     * Get name of local socket, or null if not connected
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->isConnected() ? stream_socket_get_name($this->socket) : null;
+    }
+
+    /**
+     * Get name of remote socket, or null if not connected
+     * @return string|null
+     */
+    public function getRemote(bool $pier = false): ?string
+    {
+        return $this->isConnected() ? stream_socket_get_name($this->socket, true) : null;
+    }
+
+    /**
+     * Get string representation of instance
+     * @return string String representation
+     */
+    public function __toString(): string
+    {
+        return sprintf(
+            "%s(%s)",
+            get_class($this),
+            $this->getName() ?: 'closed'
+        );
+    }
+
     protected function sendFragment($final, $payload, $opcode, $masked): void
     {
         $data = '';

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -384,11 +384,16 @@ class ClientTest extends TestCase
     {
         MockSocket::initialize('client.connect', $this);
         $client = new Client('ws://localhost:8000/my/mock/path');
+        $this->assertNull($client->getName());
+        $this->assertNull($client->getRemote());
+        $this->assertEquals('WebSocket\Client(closed)', "{$client}");
         $client->text('Connect');
         MockSocket::initialize('send-convenicance', $this);
         $client->binary(base64_encode('Binary content'));
         $client->ping();
         $client->pong();
-        $this->assertTrue(MockSocket::isEmpty());
+        $this->assertEquals('127.0.0.1:12345', $client->getName());
+        $this->assertEquals('127.0.0.1:8000', $client->getRemote());
+        $this->assertEquals('WebSocket\Client(127.0.0.1:12345)', "{$client}");
     }
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -383,6 +383,9 @@ class ServerTest extends TestCase
     {
         MockSocket::initialize('server.construct', $this);
         $server = new Server();
+        $this->assertNull($server->getName());
+        $this->assertNull($server->getRemote());
+        $this->assertEquals('WebSocket\Server(closed)', "{$server}");
         MockSocket::initialize('server.accept', $this);
         $server->accept();
         $server->text('Connect');
@@ -390,6 +393,9 @@ class ServerTest extends TestCase
         $server->binary(base64_encode('Binary content'));
         $server->ping();
         $server->pong();
+        $this->assertEquals('127.0.0.1:12345', $server->getName());
+        $this->assertEquals('127.0.0.1:8000', $server->getRemote());
+        $this->assertEquals('WebSocket\Server(127.0.0.1:12345)', "{$server}");
         $this->assertTrue(MockSocket::isEmpty());
     }
 }

--- a/tests/mock/MockSocket.php
+++ b/tests/mock/MockSocket.php
@@ -20,7 +20,7 @@ class MockSocket
         if ($function == 'get_resource_type' && is_null($current)) {
             return null; // Catch destructors
         }
-        self::$asserter->assertEquals($function, $current['function']);
+        self::$asserter->assertEquals($current['function'], $function);
         foreach ($current['params'] as $index => $param) {
             self::$asserter->assertEquals($param, $params[$index], json_encode([$current, $params]));
         }

--- a/tests/scripts/send-convenicance.json
+++ b/tests/scripts/send-convenicance.json
@@ -40,5 +40,47 @@
             "@mock-stream"
         ],
         "return": 6
+    },
+    {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "stream"
+    },
+    {
+        "function": "stream_socket_get_name",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "127.0.0.1:12345"
+    },
+    {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "stream"
+    },
+    {
+        "function": "stream_socket_get_name",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "127.0.0.1:8000"
+    },
+    {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "stream"
+    },
+    {
+        "function": "stream_socket_get_name",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "127.0.0.1:12345"
     }
 ]


### PR DESCRIPTION
* getName() - local socket name  - e.g. `127.0.0.1:8000 `
* getRemoteName() - remote socket name - e.g. `127.0.0.1:12345 `
* __toString() - string representation of instance - e.g. `WebSocket\Server(127.0.0.1:8000)`