### PR TITLE
Persistent connections still not working as intended. This fixes them.

### DIFF
--- a/lib/Base.php
+++ b/lib/Base.php
@@ -410,10 +410,21 @@ class Base implements LoggerAwareInterface
         $this->receive(); // Receiving a close frame will close the socket now.
     }
 
+    /**
+     * Disconnect from client/server.
+     */
+    public function disconnect(): void
+    {
+        if ($this->isConnected()) {
+            fclose($this->socket);
+            $this->socket = null;
+        }
+    }
+
     protected function write(string $data): void
     {
         $length = strlen($data);
-        $written = fwrite($this->socket, $data);
+        $written = @fwrite($this->socket, $data);
         if ($written === false) {
             $this->throwException("Failed to write {$length} bytes.");
         }
@@ -427,7 +438,7 @@ class Base implements LoggerAwareInterface
     {
         $data = '';
         while (strlen($data) < $length) {
-            $buffer = fread($this->socket, $length - strlen($data));
+            $buffer = @fread($this->socket, $length - strlen($data));
             if ($buffer === false) {
                 $read = strlen($data);
                 $this->throwException("Broken frame, read {$read} of stated {$length} bytes.");

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -221,6 +221,8 @@ class ClientTest extends TestCase
         MockSocket::initialize('client.connect-persistent', $this);
         $client = new Client('ws://localhost:8000/my/mock/path', ['persistent' => true]);
         $client->send('Connect');
+        $client->disconnect();
+        $this->assertFalse($client->isConnected());
         $this->assertTrue(MockSocket::isEmpty());
     }
 

--- a/tests/mock/mock-socket.php
+++ b/tests/mock/mock-socket.php
@@ -36,6 +36,11 @@ function feof()
     $args = func_get_args();
     return MockSocket::handle('feof', $args);
 }
+function ftell()
+{
+    $args = func_get_args();
+    return MockSocket::handle('ftell', $args);
+}
 function fclose()
 {
     $args = func_get_args();

--- a/tests/scripts/client.connect-persistent.json
+++ b/tests/scripts/client.connect-persistent.json
@@ -31,6 +31,13 @@
         "return": "persistent stream"
     },
     {
+        "function": "ftell",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": 0
+    },
+    {
         "function": "stream_set_timeout",
         "params": [
             "@mock-stream",
@@ -62,6 +69,27 @@
             "@mock-stream"
         ],
         "return": 13
+    },
+    {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "persistent stream"
+    },
+    {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "persistent stream"
+    },
+    {
+        "function": "fclose",
+        "params": [
+            "@mock-stream"
+        ],
+        "return":true
     }
 ]
 

--- a/tests/scripts/client.destruct.json
+++ b/tests/scripts/client.destruct.json
@@ -7,6 +7,13 @@
         "return": "stream"
     },
     {
+        "function": "get_resource_type",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": "stream"
+    },
+    {
         "function": "fclose",
         "params": [
             "@mock-stream"


### PR DESCRIPTION
I thought I had fixed persistent connections with my last commit, but I did not. I've now robustly tested that this does indeed result in connections persisting across multiple php requests (Make sure you have php-fpm configured as "pm = static").

In this change I've silenced errors on fwrite/fread, which will fail before you realize you aren't "connected", resulting in an error bubbling up to the client. This means that our logic must always account for the possible need to retry.

The usage pattern for persistent connections then looks something like this:

    class PersistentWebsocket {
        private $client = null;
    
        public function __construct($url, $timeout) {
            $this->client = new WebSocket\Client(
                $url,
                [
                    'timeout'    => $timeout,
                    'persistent' => true,
                ]
            );
        }

        public function send($request, $retry = true) {
            try {
                $this->client->send($request, 'binary');
                return $this->client->receive();
            } catch (WebSocket\ConnectionException $e) {
                if ($retry) {
                    $this->client->disconnect(); // Clear out the socket's state
                    return $this->send($request, false);
                } else {
                    throw new WireConnectionException(null, null, $e->getMessage());
                }
            }
        }
    }
