### PR TITLE
Throw client read timeout earlier and don’t close connection

### DIFF
--- a/lib/Base.php
+++ b/lib/Base.php
@@ -443,6 +443,12 @@ class Base implements LoggerAwareInterface
         while (strlen($data) < $length) {
             $buffer = @fread($this->socket, $length - strlen($data));
             if ($buffer === false) {
+                $meta = stream_get_meta_data($this->socket);
+                if (!empty($meta['timed_out'])) {
+                    $message = 'Client read timeout';
+                    $this->logger->error($message, $meta);
+                    throw new TimeoutException($message, ConnectionException::TIMED_OUT, $meta);
+                }
                 $read = strlen($data);
                 $this->throwException("Broken frame, read {$read} of stated {$length} bytes.");
             }
@@ -464,7 +470,6 @@ class Base implements LoggerAwareInterface
             fclose($this->socket);
             $this->socket = null;
         }
-        $json_meta = json_encode($meta);
         if (!empty($meta['timed_out'])) {
             $this->logger->error($message, $meta);
             throw new TimeoutException($message, ConnectionException::TIMED_OUT, $meta);

--- a/lib/Base.php
+++ b/lib/Base.php
@@ -442,13 +442,16 @@ class Base implements LoggerAwareInterface
         $data = '';
         while (strlen($data) < $length) {
             $buffer = @fread($this->socket, $length - strlen($data));
-            if ($buffer === false) {
+
+            if (!$buffer) {
                 $meta = stream_get_meta_data($this->socket);
                 if (!empty($meta['timed_out'])) {
                     $message = 'Client read timeout';
                     $this->logger->error($message, $meta);
                     throw new TimeoutException($message, ConnectionException::TIMED_OUT, $meta);
                 }
+            }
+            if ($buffer === false) {
                 $read = strlen($data);
                 $this->throwException("Broken frame, read {$read} of stated {$length} bytes.");
             }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -353,6 +353,18 @@ class ClientTest extends TestCase
         $client->receive();
     }
 
+    public function testReadTimeout(): void
+    {
+        MockSocket::initialize('client.connect', $this);
+        $client = new Client('ws://localhost:8000/my/mock/path');
+        $client->send('Connect');
+        MockSocket::initialize('receive-client-timeout', $this);
+        $this->expectException('WebSocket\TimeoutException');
+        $this->expectExceptionCode(1024);
+        $this->expectExceptionMessage('Client read timeout');
+        $client->receive();
+    }
+
     public function testEmptyRead(): void
     {
         MockSocket::initialize('client.connect', $this);

--- a/tests/scripts/receive-client-timeout.json
+++ b/tests/scripts/receive-client-timeout.json
@@ -17,12 +17,12 @@
             "@mock-stream"
         ],
         "return": {
-            "timed_out": false,
+            "timed_out": true,
             "blocked": true,
-            "eof": true,
+            "eof": false,
             "stream_type": "tcp_socket\/ssl",
             "mode": "r+",
-            "unread_bytes": 2,
+            "unread_bytes": 0,
             "seekable": false
         }
     },
@@ -34,19 +34,11 @@
         "return": "stream"
     },
     {
-        "function": "stream_get_meta_data",
+        "function": "get_resource_type",
         "params": [
             "@mock-stream"
         ],
-        "return": {
-            "timed_out": false,
-            "blocked": true,
-            "eof": true,
-            "stream_type": "tcp_socket\/ssl",
-            "mode": "r+",
-            "unread_bytes": 2,
-            "seekable": false
-        }
+        "return": "stream"
     },
     {
         "function": "fclose",

--- a/tests/scripts/receive-empty-read.json
+++ b/tests/scripts/receive-empty-read.json
@@ -12,6 +12,21 @@
         "return": ""
     },
     {
+        "function": "stream_get_meta_data",
+        "params": [
+            "@mock-stream"
+        ],
+        "return": {
+            "timed_out": false,
+            "blocked": true,
+            "eof": false,
+            "stream_type": "tcp_socket\/ssl",
+            "mode": "r+",
+            "unread_bytes": 0,
+            "seekable": false
+        }
+    },
+    {
         "function": "get_resource_type",
         "params": [
             "@mock-stream"


### PR DESCRIPTION
PR to solve issue #139 

When a timeout occurs on the client-side in the `$client->receive()` call this throws a TimeoutException earlier and keeps the connection open. This allows a PING to be sent to keep the connection alive if needed by the server.