### PR TITLE
Set a getter for get_path_query.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 composer.lock
 composer.phar
 vendor/
+.idea

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -24,7 +24,7 @@ class Client extends Base
       'timeout'       => 5,
     ];
 
-    protected string $pathWithQuery;
+    protected $pathWithQuery;
     protected $socket_uri;
 
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -24,7 +24,17 @@ class Client extends Base
       'timeout'       => 5,
     ];
 
+    protected string $pathWithQuery;
     protected $socket_uri;
+
+
+    /**
+     * @return string
+     */
+    public function getPathWithQuery(): string
+    {
+        return str_replace(" ", "%20", $this->pathWithQuery);
+    }
 
     /**
      * @param string $uri     A ws/wss-URI
@@ -70,12 +80,12 @@ class Client extends Base
         $query     = isset($url_parts['query'])    ? $url_parts['query'] : '';
         $fragment  = isset($url_parts['fragment']) ? $url_parts['fragment'] : '';
 
-        $path_with_query = $path;
+        $this->pathWithQuery = $path;
         if (!empty($query)) {
-            $path_with_query .= '?' . $query;
+            $this->pathWithQuery .= '?' . $query;
         }
         if (!empty($fragment)) {
-            $path_with_query .= '#' . $fragment;
+            $this->pathWithQuery .= '#' . $fragment;
         }
 
         if (!in_array($scheme, ['ws', 'wss'])) {
@@ -128,7 +138,7 @@ class Client extends Base
             throw new ConnectionException($error);
         }
 
-        $address = "{$scheme}://{$host}{$path_with_query}";
+        $address = "{$scheme}://{$host}{$this->getPathWithQuery()}";
 
         if (!$persistent || ftell($this->socket) == 0) {
             // Set timeout on the stream as well.
@@ -162,7 +172,7 @@ class Client extends Base
                 $headers = array_merge($headers, $this->options['headers']);
             }
 
-            $header = "GET " . $path_with_query . " HTTP/1.1\r\n" . implode(
+            $header = "GET " . $this->getPathWithQuery() . " HTTP/1.1\r\n" . implode(
                 "\r\n",
                 array_map(
                     function ($key, $value) {


### PR DESCRIPTION
hi 
dear Sören Jensen
I had used your websocket-php , it was great but I find out tiny problem.
it started since they changed their main site( before that it didn't have any space between word in URL, after that they update the site and add User-Agent in URL as new parameter.)
last URL was like this " wss://chat.divar.ir/socket/websocket?token={token}&device_type=web&vsn=1.0.0 ", But new one is "  wss://chat.divar.ir/socket/websocket?token={token}&device_type=web&device_model=Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0&version=2.10.4&vsn=1.0.0 " 
the main problem was space between character. due to this reason I couldn't find  HTTP header request  

I would be happy to you give me any advice.
tnx for your attention