### PR TITLE
ensure req path is valid

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -310,8 +310,13 @@ class Client implements LoggerAwareInterface
             ->withScheme($this->socket_uri->getScheme() == 'wss' ? 'ssl' : 'tcp')
             ->withPort($this->socket_uri->getPort());
 
+        $path = $this->socket_uri->getPath();
+        if ($path === '') {
+            $path = '/';
+        }
+
         $http_uri = (new Uri())
-            ->withPath($this->socket_uri->getPath())
+            ->withPath($path)
             ->withQuery($this->socket_uri->getQuery())
             ->withFragment($this->socket_uri->getFragment());
 


### PR DESCRIPTION
Currently, v1.6.0 sends `GET  HTTP/1.1` req header when path is empty. That is not valid. It should match `^[\S]+\s+([a-zA-Z]+:\/\/|\/).*`

This ensures it sends at least `GET / HTTP/1.1`

https://regex101.com/r/m1yhcd/1

(https://github.com/Textalk/websocket-php/commit/271831ea6bceb3acbcdd723bdb3df9a4038736ca#diff-a09fdefaa87bc575c5dd55a06a4b034b7982d12bb6d6cf4cf4e214c7f13c2f3fR399)