### PR TITLE
Fix client path for http request

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -310,10 +310,15 @@ class Client implements LoggerAwareInterface
             ->withScheme($this->socket_uri->getScheme() == 'wss' ? 'ssl' : 'tcp')
             ->withPort($this->socket_uri->getPort());
 
+        // Path must be absolute
+        $http_path = $this->socket_uri->getPath();
+        if ($http_path === '' || $http_path[0] !== '/') {
+            $http_path = "/{$http_path}";
+        }
+
         $http_uri = (new Uri())
-            ->withPath($this->socket_uri->getPath())
-            ->withQuery($this->socket_uri->getQuery())
-            ->withFragment($this->socket_uri->getFragment());
+            ->withPath($http_path)
+            ->withQuery($this->socket_uri->getQuery());
 
         // Set the stream context options if they're already set in the config
         if (isset($this->options['context'])) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -64,6 +64,24 @@ class ClientTest extends TestCase
         $this->assertTrue(MockSocket::isEmpty());
     }
 
+    public function testClientNoPath(): void
+    {
+        MockSocket::initialize('client.connect-root', $this);
+        $client = new Client('ws://localhost:8000');
+        $client->send('Connect');
+        $this->assertTrue(MockSocket::isEmpty());
+    }
+
+    public function testClientRelativePath(): void
+    {
+        MockSocket::initialize('client.connect', $this);
+        $uri = new Uri('ws://localhost:8000');
+        $uri = $uri->withPath('my/mock/path');
+        $client = new Client($uri);
+        $client->send('Connect');
+        $this->assertTrue(MockSocket::isEmpty());
+    }
+
     public function testClientWithTimeout(): void
     {
         MockSocket::initialize('client.connect-timeout', $this);

--- a/tests/mock/MockSocket.php
+++ b/tests/mock/MockSocket.php
@@ -21,6 +21,9 @@ class MockSocket
         }
         self::$asserter->assertEquals($current['function'], $function);
         foreach ($current['params'] as $index => $param) {
+            if (isset($current['input-op'])) {
+                $param = self::op($current['input-op'], $params, $param);
+            }
             self::$asserter->assertEquals($param, $params[$index], json_encode([$current, $params]));
         }
         if (isset($current['error'])) {
@@ -67,7 +70,7 @@ class MockSocket
             case 'key-save':
                 preg_match('#Sec-WebSocket-Key:\s(.*)$#mUi', $params[1], $matches);
                 self::$stored['sec-websocket-key'] = trim($matches[1]);
-                return $data;
+                return str_replace('{key}', self::$stored['sec-websocket-key'], $data);
             case 'key-respond':
                 $key = self::$stored['sec-websocket-key'] . '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
                 $encoded = base64_encode(pack('H*', sha1($key)));

--- a/tests/scripts/client.connect-root.json
+++ b/tests/scripts/client.connect-root.json
@@ -35,7 +35,7 @@
         "function": "fwrite",
         "params": [
             "@mock-stream",
-            "GET /my/mock/path?my_query=yes HTTP/1.1\r\nHost: localhost:8000\r\nUser-Agent: websocket-client-php\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n\r\n"
+            "GET / HTTP/1.1\r\nHost: localhost:8000\r\nUser-Agent: websocket-client-php\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n\r\n"
         ],
         "input-op": "key-save",
         "return": 224

--- a/tests/scripts/client.connect.json
+++ b/tests/scripts/client.connect.json
@@ -33,10 +33,12 @@
     },
     {
         "function": "fwrite",
+        "regexp": true,
         "params": [
-            "@mock-stream"
+            "@mock-stream",
+            "GET /my/mock/path HTTP/1.1\r\nHost: localhost:8000\r\nUser-Agent: websocket-client-php\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n\r\n"
         ],
-        "return-op": "key-save",
+        "input-op": "key-save",
         "return": 199
     },
     {


### PR DESCRIPTION
Fulfilling expectations for HTTP request target
* Path must be absolute (i.e. beginning with `/`)
* Fragment should not be included, only path and query
* Improved testing of generated headers

Extends https://github.com/Textalk/websocket-php/pull/165