### PR TITLE
Allow psr/http-message 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "phrity/net-uri": "^1.0",
         "phrity/util-errorhandler": "^1.0",
         "psr/log": "^1.0 | ^2.0 | ^3.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 | ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
According to the release notes (https://github.com/php-fig/http-message/releases/tag/2.0) changes _MAY_ be implemented, but these changes aren't required, hence it's possible to use version 1.x and 2.x

Version 1.6 of websocket-php added the usage of psr/http-message, but currently I can't upgrade from `1.5.8` to `1.6.3` because my project requires `psr/http-message@^2.0`