### PR TITLE
Fix laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "phrity/net-uri": "^1.0",
         "phrity/util-errorhandler": "^1.0",
         "psr/log": "^1.0 | ^2.0 | ^3.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 | ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
Problem 1
    - Root composer.json requires textalk/websocket ^1.6 -> satisfiable by textalk/websocket[1.6.0, 1.6.1, 1.6.2, 1.6.3].
    - textalk/websocket[1.6.0, ..., 1.6.3] require psr/http-message ^1.0 -> found psr/http-message[1.0, 1.0.1, 1.1] but the package is fixed to 2.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command